### PR TITLE
ci: add not-real workflow

### DIFF
--- a/.github/workflows/not-real.yml
+++ b/.github/workflows/not-real.yml
@@ -1,0 +1,37 @@
+name: CI - not-real tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - ci/**
+
+jobs:
+  test-not-real:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests (not-real)
+        run: |
+          python -m pip install pytest
+          python -m pytest -q -m "not real"
+
+      - name: Upload pytest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-not-real-report
+          path: .pytest_cache

--- a/.github/workflows/real.yml
+++ b/.github/workflows/real.yml
@@ -1,0 +1,33 @@
+name: CI - real tests (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-real:
+    name: Run real tests on self-hosted runner
+    runs-on: [self-hosted, windows, real]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests (real)
+        run: |
+          python -m pytest -q -m real
+
+      - name: Upload pytest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-real-report
+          path: .pytest_cache

--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ Notas:
 - `pytest.ini` en este repositorio establece por defecto `-m "real"` (histórico). El wrapper facilita ejecutar el modo más habitual local (`not-real`).
 - Si necesitas que adapte `tsc_sim.bat`/`tsc_real.bat` para invocar este wrapper o para documentar los requisitos del DLL, dímelo y lo añado.
 
+### Ejecutar tests `real` (self-hosted)
+
+Los tests marcados `real` requieren acceso al entorno RailDriver/Train Simulator y a bibliotecas nativas (DLL). No se ejecutan en runners hospedados por GitHub sin configuración adicional.
+
+- Hemos añadido un workflow manual: `.github/workflows/real.yml`. Usa `workflow_dispatch` y espera un runner Windows self-hosted etiquetado `real`.
+- Requisitos del runner:
+    - Windows x64 con Python 3.11 y dependencias de `requirements.txt`.
+    - RailDriver / Train Simulator DLLs instaladas y accesibles. Configure `TSC_RD_DLL_DIR` o `RAILWORKS_PLUGINS` como variable de entorno en el runner si hace falta.
+    - Opcionalmente, configure `TSC_RD` si su setup expone un endpoint TCP para el bridge.
+
+Para ejecutar localmente (si tiene hardware/DLLs configurados):
+
+```powershell
+# ejecutar tests reales localmente (asegúrese de setear las variables de entorno necesarias)
+.\scripts\run-tests.ps1 real
+```
+
 
 Para entornos de producción o integración continua es útil controlar parámetros de SQLite y disponer de un healthcheck sencillo.
 

--- a/scripts/run_pytests.py
+++ b/scripts/run_pytests.py
@@ -17,15 +17,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pytest-args", nargs="*", help="Additional args passed to pytest")
     args = parser.parse_args(argv)
 
-    # Ensure minimal DB for tests that expect it when running not-real
-    if args.mode == "not-real":
-        try:
-            from scripts._ensure_test_db import ensure_db
-
-            ensure_db()
-        except Exception:
-            # best-effort; continue to pytest which may skip or fail
-            pass
+    # The test DB is created by an autouse fixture in conftest.py when needed.
 
     # Build pytest args
     py_args = []


### PR DESCRIPTION
Run pytest -m 'not real' on PRs and pushes to provide fast feedback for tests that don't require hardware.