### PR TITLE
ci: add real runner validation, docs and smoke test

### DIFF
--- a/.github/workflows/real.yml
+++ b/.github/workflows/real.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate runner (pre-check)
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate_real_runner.ps1
+        shell: powershell
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TrainSimAI (TSC)
 
 [![CI](https://github.com/doski2/TrainSimAI/actions/workflows/ci-mypy-safety.yml/badge.svg)](https://github.com/doski2/TrainSimAI/actions/workflows/ci-mypy-safety.yml)
+[![Not-real tests](https://github.com/doski2/TrainSimAI/actions/workflows/not-real.yml/badge.svg)](https://github.com/doski2/TrainSimAI/actions/workflows/not-real.yml)
 
 Autopiloto/analizador para **Train Simulator Classic** (Windows, Python 64-bit).
 Pipeline: **GetData → Bus LUA → Collector → Distancia próximo límite → Frenada v0 (offline/online)** con trazas y tests.
@@ -243,6 +244,8 @@ data/        # Artefactos locales (no versionar)
 Hemos añadido un pequeño helper para ejecutar los tests localmente con modos claros:
 
 - `scripts/run-tests.ps1` — PowerShell wrapper con modos `all`, `not-real` (por defecto) y `real`.
+
+Consulta `docs/REAL_RUNNER_SETUP.md` para instrucciones sobre cómo configurar un runner self-hosted para ejecutar los tests `real`.
 
 Uso (PowerShell):
 

--- a/docs/REAL_RUNNER_SETUP.md
+++ b/docs/REAL_RUNNER_SETUP.md
@@ -1,0 +1,67 @@
+# Configuración del runner self-hosted para tests `real`
+
+Este documento describe los pasos recomendados para provisionar un runner self-hosted en Windows que pueda ejecutar los tests marcados `real` en este repositorio.
+
+Resumen
+--------
+- Objetivo: disponer de un runner Windows con acceso a las bibliotecas nativas (RailDriver / Train Simulator DLLs) y con la etiqueta `real` para que GitHub Actions pueda ejecutar manualmente el workflow `.github/workflows/real.yml`.
+
+Requisitos mínimos del host
+---------------------------
+- Windows 10/11 o Windows Server 2019/2022 (x64).
+- Python 3.11 (preferido), pip y acceso de administrador para instalar el runner de GitHub Actions.
+- Conexión de red estable y acceso al repositorio (token del runner configurado por GitHub).
+- Espacio en disco suficiente para dependencias y artefactos de prueba.
+
+Instalación del runner de GitHub Actions (resumen)
+-------------------------------------------------
+1. Crear una máquina Windows y entrar como usuario administrador.
+2. En la página de `Settings -> Actions -> Runners` de tu repositorio/organización, generar un nuevo runner y copia la URL y el token.
+3. En la máquina, descargar y extraer el runner, luego ejecutar `config.cmd` con el token. Ejemplo PowerShell (ejecutar como Admin):
+
+```powershell
+# extraer en C:\actions-runner
+cd C:\actions-runner
+.\config.cmd --url https://github.com/<OWNER>/<REPO> --token <TOKEN> --labels windows,real
+```
+
+4. Instalar como servicio (opcional) para persistencia y autorestart:
+
+```powershell
+.\svcinstall.cmd
+Start-Service actions.runner.<OWNER>-<REPO>.<NAME>
+```
+
+Etiquetado
+---------
+Al configurar el runner, añade la etiqueta `real` (ej. `--labels windows,real`) para que el workflow `.github/workflows/real.yml` pueda apuntar a él.
+
+Variables de entorno y configuración necesarias
+---------------------------------------------
+- `TSC_RD_DLL_DIR` (recomendado): directorio donde se encuentran las DLL del RailDriver/Train Simulator que el proceso `ingestion/rd_impl_real.py` requiere.
+- `RAILWORKS_PLUGINS` (opcional): ruta alternativa usada por algunas instalaciones de RailWorks/Train Simulator.
+- `TSC_RD` (opcional): si el entorno expone un endpoint RailDriver TCP, establecer `tcp://host:port`.
+
+Recomendación de seguridad
+-------------------------
+- No poner rutas con credenciales en el repo. Configure las variables de entorno directamente en la máquina del runner o mediante `Environment variables` de la configuración del runner (no en el repositorio).
+- Limitar acceso al runner: usar una cuenta de servicio con permisos mínimos necesarios y aplicar actualizaciones y un antivirus/endpoint adecuado.
+
+Checks y preflight
+-------------------
+Antes de ejecutar la suite `real`, se recomienda comprobar:
+
+- Python y dependencias (ejecutar `python -m pip install -r requirements.txt`).
+- Que las DLL existen en `TSC_RD_DLL_DIR` y son accesibles por el usuario del runner.
+- Que la red/puerto del RailDriver (si se usa) es accesible desde el runner.
+
+Uso desde GitHub Actions
+------------------------
+El workflow `real.yml` en este repositorio usa `runs-on: [self-hosted, windows, real]`. El job será programado en cualquier runner que tenga las etiquetas `self-hosted`, `windows` y `real`.
+
+Notas adicionales
+----------------
+- Si necesitas compartir el runner entre varios repositorios, considera crear un runner a nivel de organización y controlar el acceso mediante equipos.
+- Para pruebas repetibles, documenta la versión exacta de las DLL y del juego utilizado; pequeñas diferencias de versión pueden afectar la API nativa.
+
+Si quieres, puedo añadir un script de validación que verifique la presencia de las DLL y las variables de entorno; también puedo añadir un test de humo en `tests/` para que la suite `real` haga un skip controlado si falta la configuración.

--- a/scripts/validate_real_runner.ps1
+++ b/scripts/validate_real_runner.ps1
@@ -1,0 +1,60 @@
+<#
+Validate the host is prepared for running `real` tests.
+
+Checks performed:
+- Python executable in PATH
+- pip can install packages from requirements.txt (checks by invoking 'pip check' after install)
+- environment variables `TSC_RD_DLL_DIR` or `RAILWORKS_PLUGINS` point to a directory containing .dll files
+
+Exit codes:
+0 = ok
+1 = missing python
+2 = pip/install failure
+3 = missing DLL dir or no DLLs
+
+#>
+param()
+
+function Fail([int]$code, [string]$msg) {
+    Write-Error $msg
+    exit $code
+}
+
+Write-Host "Validating real runner prerequisites..."
+
+# Check python
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) { Fail 1 "Python is not found in PATH. Install Python 3.11 and ensure it's available as 'python'" }
+
+Write-Host "Python found: $($python.Path)"
+
+# Check pip & install requirements (dry-run: try to import requirements)
+try {
+    & python -m pip install --upgrade pip | Out-Null
+    if (Test-Path requirements.txt) {
+        Write-Host "Installing requirements from requirements.txt (this may take a while)..."
+        & python -m pip install -r requirements.txt
+        if ($LASTEXITCODE -ne 0) { Fail 2 "pip install -r requirements.txt failed with exit code $LASTEXITCODE" }
+    } else {
+        Write-Host "No requirements.txt found in repo root, skipping pip install step"
+    }
+} catch {
+    Fail 2 "Exception while installing requirements: $_"
+}
+
+# Check for DLL folder
+$dllDir = $env:TSC_RD_DLL_DIR; if (-not $dllDir) { $dllDir = $env:RAILWORKS_PLUGINS }
+if (-not $dllDir) {
+    Fail 3 "Neither TSC_RD_DLL_DIR nor RAILWORKS_PLUGINS are defined. Set one to the folder containing the RailDriver DLLs."
+}
+
+if (-not (Test-Path $dllDir)) { Fail 3 "DLL directory '$dllDir' does not exist" }
+
+$dlls = Get-ChildItem -Path $dllDir -Filter *.dll -File -ErrorAction SilentlyContinue
+if (-not $dlls -or $dlls.Count -eq 0) { Fail 3 "No .dll files found in '$dllDir'" }
+
+Write-Host "Found DLLs in ${dllDir}:"
+$dlls | ForEach-Object { Write-Host " - $($_.Name)" }
+
+Write-Host "Validation OK"
+exit 0

--- a/tests/test_real_smoke.py
+++ b/tests/test_real_smoke.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+
+
+def _has_rd_dlls() -> bool:
+    dll_dir = os.environ.get("TSC_RD_DLL_DIR") or os.environ.get("RAILWORKS_PLUGINS")
+    if not dll_dir:
+        return False
+    # basic check: any .dll file in the directory
+    try:
+        for f in os.listdir(dll_dir):
+            if f.lower().endswith('.dll'):
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _has_rd_endpoint() -> bool:
+    rd = os.environ.get("TSC_RD")
+    return bool(rd)
+
+
+def test_real_smoke_check():
+    """Smoke check for real tests: skip if no DLLs or RD endpoint configured.
+
+    This avoids noisy failures when running on runners that are not prepared.
+    """
+    if not (_has_rd_dlls() or _has_rd_endpoint()):
+        pytest.skip("Skipping real tests: no TSC_RD_DLL_DIR/RAILWORKS_PLUGINS or TSC_RD configured on this runner")
+
+    # Basic import sanity check (do not raise if it imports but cannot connect)
+    try:
+        import importlib
+
+        importlib.import_module("ingestion.rd_impl_real")
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"Skipping real tests: ingestion.rd_impl_real import failed: {exc}")
+
+    assert True


### PR DESCRIPTION
Adds: \n- validation step and script scripts/validate_real_runner.ps1 for self-hosted runners\n- docs docs/REAL_RUNNER_SETUP.md describing how to provision a Windows runner labeled 'real'\n- tests/test_real_smoke.py that skips when DLLs or TSC_RD are not configured\n- README badge for not-real CI\nThis PR contains commits made after PR #7 was merged; it updates CI and adds runner validation/docs for running the 'real' suite.