### PR TITLE
ci: add pre-commit hooks and self-hosted real-tests workflow

### DIFF
--- a/.github/workflows/real.yml
+++ b/.github/workflows/real.yml
@@ -1,3 +1,45 @@
+name: CI - real tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - ci/**
+
+jobs:
+  real-tests:
+    name: Run real tests on self-hosted Windows runners
+    runs-on: [self-hosted, windows]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate runner environment
+        run: pwsh -File .\scripts\validate_real_runner.ps1
+
+      - name: Run real tests
+        run: |
+          python -m pytest -q -m real --junitxml=pytest-results-real.xml | Tee-Object -FilePath pytest-real.log
+
+      - name: Upload pytest results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-real-report
+          path: |
+            pytest-results-real.xml
+            pytest-real.log
 name: CI - real tests (manual)
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,22 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.13.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.0
+    hooks:
+      - id: black
+        args: [--fast]
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.12.0
+    hooks:
+      - id: isort
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.5.0
     hooks:
       - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+Nota: después de instalar, es habitual que `pre-commit` modifique archivos (por ejemplo `ruff --fix` o `black`). Revise los cambios con `git status` y haga un commit adicional si el hook aplica correcciones automáticas.
+
+
 Observabilidad (Prometheus)
 ---------------------------
 - El cliente RD (`ingestion/rd_client.py`) puede exponer métricas Prometheus opcionalmente.


### PR DESCRIPTION
Adds pre-commit (ruff/black/isort) and a self-hosted Windows job for running tests marked 'real' with a validation step.